### PR TITLE
MARBLE-1340 replace marble.library.nd.edu links with updated marble.nd.edu

### DIFF
--- a/content/configuration.js
+++ b/content/configuration.js
@@ -39,7 +39,7 @@ module.exports = {
     title: 'Digital Collections',
     author: 'ndlib',
     description: 'Notre Dame Digital Collections',
-    siteUrl: 'https://marble.library.nd.edu',
+    siteUrl: 'https://marble.nd.edu',
     // apis and embedded urls
     // universalViewerBaseURL: 'https://viewer-iiif.library.nd.edu/universalviewer/index.html',
 

--- a/content/schema/basicschema2.json
+++ b/content/schema/basicschema2.json
@@ -5,5 +5,5 @@
   "description": "I wish there were more hours in the day.",
   "dateCreated": "2016-01-01",
   "dateModified": "2018-04-16",
-  "license": "https://marble.library.nd.edu/"
+  "license": "https://marble.nd.edu/"
 }

--- a/content/schema/basicschema3.json
+++ b/content/schema/basicschema3.json
@@ -6,5 +6,5 @@
   "alternateTitle": "The Answer to Everything... and More",
   "dateCreated": "2016-01-01",
   "dateModified": "2018-04-16",
-  "license": "https://marble.library.nd.edu/"
+  "license": "https://marble.nd.edu/"
 }


### PR DESCRIPTION
<img width="1068" alt="Screen Shot 2021-01-18 at 4 01 29 PM" src="https://user-images.githubusercontent.com/38439231/104963786-46606680-59a9-11eb-9d4b-01ef63528937.png">
