### PR TITLE
Narrow homepage text under banner

### DIFF
--- a/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -60,7 +60,7 @@ const IndexPage = ({ location }) => {
   return (
     <React.Fragment>
       <BaseStyles>
-        <p dangerouslySetInnerHTML={{ __html: t('common:hompageDescriptive') }} />
+        <p sx={{ margin: '3rem' }} dangerouslySetInnerHTML={{ __html: t('common:hompageDescriptive') }} />
         <h2>{t('common:search.browseBy')}</h2>
       </BaseStyles>
       <Flex sx={{ flexWrap: 'wrap' }}>

--- a/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -60,7 +60,7 @@ const IndexPage = ({ location }) => {
   return (
     <React.Fragment>
       <BaseStyles>
-        <p sx={{ margin: '3rem' }} dangerouslySetInnerHTML={{ __html: t('common:hompageDescriptive') }} />
+        <p sx={{ maxWidth: ['100%', '80rem', '80rem'] }} dangerouslySetInnerHTML={{ __html: t('common:hompageDescriptive') }} />
         <h2>{t('common:search.browseBy')}</h2>
       </BaseStyles>
       <Flex sx={{ flexWrap: 'wrap' }}>


### PR DESCRIPTION
MARBLE-1497 
<img width="1437" alt="Screen Shot 2021-03-15 at 2 50 46 PM" src="https://user-images.githubusercontent.com/38439231/111208013-9d954880-85a0-11eb-890d-ec8b45d04f2f.png">
