### PR TITLE
Add Featured Items header to main page

### DIFF
--- a/src/@ndlib/gatsby-theme-marble/components/App/Pages/Portfolio/PortfolioBody/PortfolioTitle/TitleEdit/sx.js
+++ b/src/@ndlib/gatsby-theme-marble/components/App/Pages/Portfolio/PortfolioBody/PortfolioTitle/TitleEdit/sx.js
@@ -16,6 +16,7 @@ module.exports = {
     '& > button': {
       marginLeft: '.5rem',
     },
+    display: 'block',
   },
   warning: {
     fontSize: '.7rem',

--- a/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -91,6 +91,9 @@ const IndexPage = ({ location }) => {
           />
         </Box>
       </Flex>
+      <BaseStyles>
+        <h2>{t('common:search.featuredItems')}</h2>
+      </BaseStyles>
       <CardGroup
         label={t('common:search.recentAdditions')}
         toggleGroup='homepage'


### PR DESCRIPTION
MARBLE-1561, 1619
Add 'Featured Items' header on main page. Fix formatting of 'Cancel' button on editing portfolio title.
<img width="1280" alt="Screen Shot 2021-05-13 at 11 09 08 AM" src="https://user-images.githubusercontent.com/38439231/118154657-516e5500-b3e5-11eb-947a-1d0c703e5624.png">
<img width="1280" alt="Screen Shot 2021-05-13 at 12 07 19 PM" src="https://user-images.githubusercontent.com/38439231/118154661-53381880-b3e5-11eb-974c-201a53b16a14.png">
