### PR TITLE
Fix how pageName renders

### DIFF
--- a/src/@ndlib/gatsby-theme-marble/components/Pages/HelpPage/HelpContent/index.js
+++ b/src/@ndlib/gatsby-theme-marble/components/Pages/HelpPage/HelpContent/index.js
@@ -64,6 +64,9 @@ export const getPageName = (location) => {
   if (pathname[0] === '/') {
     pathname = pathname.slice(1)
   }
+  if (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1)
+  }
   if (pathname.startsWith('help/')) {
     pathname = pathname
       .replace('help/', '')


### PR DESCRIPTION
MARBLE-1600 After short back and forth, PO would like help page information to render when url ends with a slash.