### PR TITLE
Don't display horizontal scrollbar when not necessary.

### DIFF
--- a/src/components/Pages/DisclaimerPage/index.js
+++ b/src/components/Pages/DisclaimerPage/index.js
@@ -8,7 +8,7 @@ import NDBrandBreadcrumbs from '@ndlib/gatsby-theme-marble/src/components/Shared
 const DisclaimerPage = () => {
   const { t } = useTranslation()
   return (
-    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', minWidth: '90vw' } }}>
+    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', minWidth: '100%' } }}>
       <NDBrandBreadcrumbs
         currentPageTitle={t('text:disclaimerPage.title')}
         breadcrumbs={[]}

--- a/src/components/Pages/IndexPage/index.js
+++ b/src/components/Pages/IndexPage/index.js
@@ -74,7 +74,7 @@ const IndexPage = ({ location }) => {
           {t('common:search.browseBy')}
         </Heading>
 
-        <Flex sx={{ flexWrap: 'wrap', width: '100%', minWidth: '90vw' }}>
+        <Flex sx={{ flexWrap: 'wrap', width: '100%' }}>
           <Box sx={{ width: ['100%', '100%', '33.3%'], px: '1rem', py: '.5rem' }}>
             <BrowseBar
               label='Date'

--- a/src/components/Pages/PrivacyPolicyPage/index.js
+++ b/src/components/Pages/PrivacyPolicyPage/index.js
@@ -8,7 +8,7 @@ import NDBrandBreadcrumbs from '@ndlib/gatsby-theme-marble/src/components/Shared
 const PrivacyPolicyPage = () => {
   const { t } = useTranslation()
   return (
-    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', minWidth: '90vw' } }}>
+    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', width: '100%' } }}>
       <NDBrandBreadcrumbs
         currentPageTitle={t('text:privacyPolicyPage.title')}
         breadcrumbs={[]}

--- a/src/components/Pages/StatsPage/index.js
+++ b/src/components/Pages/StatsPage/index.js
@@ -84,7 +84,7 @@ const StatsPage = () => {
 
   const pageTitle = 'Statistics'
   return (
-    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', minWidth: '90vw' } }}>
+    <NDBrandSection variant='fullBleed' sx={{ '& div.sectionContent': { maxWidth: 'inherit', width: '100%' } }}>
       <NDBrandBreadcrumbs
         currentPageTitle={pageTitle}
         breadcrumbs={[]}

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -98,7 +98,7 @@ export default merge(theme, {
     },
     navTop: {
       '& div':{
-        minWidth: ['100vw', '100vw', '100vw', '34rem'],
+        minWidth: ['100%', '100%', '100%', '34rem'],
       },
     },
   },


### PR DESCRIPTION
Using `vw` for layout is an issue when you assume that the page width should equal `100vw`. The browser may interpret view width to include the space where the vertical scrollbar is. This in turn causes the page contents to extend outside the boundaries of what is "visible", so you end up with a horizontal scrollbar for that little extra width. Most layout elements should be sized relative to their parent anyway. If you were to set a max-width on the parent container, you want it to fill the space within the bounds of the parent, not go beyond it because 90vw or 100vw happens to be wider.